### PR TITLE
Fix Windows CI build: pin to windows-2022 runner

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -64,7 +64,12 @@ jobs:
           ldd --version
 
   build-windows:
-    runs-on: windows-latest
+    # Pin to windows-2022 (Visual Studio 2022 / v17). The windows-latest image
+    # now ships Visual Studio 2026 (v18), which the bundled node-gyp can't
+    # detect — its PowerShell VS-finder overflows the stdio buffer
+    # (ERR_CHILD_PROCESS_STDIO_MAXBUFFER) and reports the VS version as
+    # "undefined", so compiling native deps (@vscode/sqlite3) fails.
+    runs-on: windows-2022
     name: Build Windows x64
     # Only build Windows on manual dispatch when explicitly requested.
     # Tag pushes (releases) ship Linux only by default — request a Windows


### PR DESCRIPTION
## Problem

The Windows build job (`build-windows` in `.github/workflows/build-all.yml`) has been failing during `npm ci`. The native dependency `@vscode/sqlite3` compiles via `node-gyp`, and the `windows-latest` runner — recently upgraded to **Windows Server 2025 shipping Visual Studio 2026 (v18)** — breaks that step. The bundled `node-gyp` can't detect VS 18: its PowerShell VS-finder overflows the child-process output buffer (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`), reports the VS version as `undefined`, and aborts:

```
gyp ERR! find VS unknown version "undefined" found at "C:\Program Files\Microsoft Visual Studio\18\Enterprise"
gyp ERR! find VS could not find a version of Visual Studio 2017 or newer to use
```

The last successful Windows build ran on the older image with VS 2022. No project code changed — only the runner image did.

## Fix

Pin the Windows job from `windows-latest` → `windows-2022` (Visual Studio 2022 / v17), which `node-gyp` detects correctly. Added a comment explaining why the pin is necessary.

## Testing

Once merged (or dispatched from this branch), run **Build All Platforms** via workflow dispatch with the "Also build Windows installers" option enabled to produce the portable and NSIS `.exe` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLAjMwfcnf6Sr7q74pZeYe)_